### PR TITLE
ユーザー・スポット一覧作成、トップ画面編集ほか

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -27,6 +27,7 @@ class SpotsController < ApplicationController
   end
 
   def index
+    @spots = Spot.page(params[:page]).reverse_order
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!, { only: [:index] }
   before_action :baria_user, { only: [:edit, :update] }
 
   def show
@@ -11,6 +12,7 @@ class UsersController < ApplicationController
   end
 
   def index
+    @users = User.page(params[:page]).reverse_order
   end
 
   def edit

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,8 +1,4 @@
-<h2>Log in</h2>
-
-<% if flash.now[:alert] %>
-  <%= flash.now[:alert] %>
-<% end %>
+<h2>ログイン</h2>
 
 <%= form_with model: @user, url: user_session_path, local: true do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,12 @@
           <%= link_to "新規投稿", new_spot_path %>
         </li>
         <li>
+          <%= link_to "スポット一覧", spots_path %>
+        </li>
+        <li>
+          <%= link_to "ユーザー一覧", users_path %>
+        </li>
+        <li>
           <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
         </li>
       <% else %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,2 +1,41 @@
-<h1>Spots#index</h1>
-<p>Find me in app/views/spots/index.html.erb</p>
+<h2>スポット一覧</h2>
+
+<% @spots.each do |spot| %>
+  <div>
+    <div>
+      フォト：
+      <%= attachment_image_tag spot, :spot_image1, format: "jpeg", fallback: "noimage-1-760x460.png", size: "100x100" %>
+    </div>
+    <p>タイトル：
+      <%= link_to spot_path(spot) do %>
+        <%= spot.title %>
+      <% end %>
+    </p>
+    <p>投稿日：<%= spot.created_at.strftime("%Y年%-m月%-d日") %></p>
+    <p>
+      <% if spot.visited_day.nil? %>
+        来訪日: 不明
+      <% else %>
+        来訪日: <%= spot.visited_day.strftime("%Y年%-m月%-d日") %>
+      <% end %>
+    </p>
+    <% if spot.rate.nil? %>
+      <p>無評価</p>
+    <% else %>
+      <p id="star-rate-<%= spot.id %>"></p>
+      <script>
+        $('#star-rate-<%= spot.id %>').raty({
+          size: 36,
+          starOff: '<%= asset_path('star-off.png') %>',
+          starOn: '<%= asset_path('star-on.png') %>',
+          readOnly: true,
+          score: <%= spot.rate %>,
+        });
+      </script>
+    <% end %>
+    <div class="favorite-<%= spot.id %>">
+      <%= render "favorites/list_favorite", spot: spot %>
+    </div>
+  </div>
+<% end %>
+<%= paginate @spots %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,2 +1,18 @@
-<h1>Users#index</h1>
-<p>Find me in app/views/users/index.html.erb</p>
+<h2>ユーザー一覧</h2>
+
+<% @users.each do |user| %>
+  <div>
+    <div>
+      フォト：
+      <%= attachment_image_tag user, :profile_image, format: "jpeg", fallback: "noimage-1-760x460.png", size: "100x100" %>
+    </div>
+    <p>ニックネーム：<%= user.nickname %></p>
+    <p>年齢：<%= user.age %></p>
+    <p>性別：<%= user.sex %></p>
+    <p>都道府県：<%= user.prefecture %></p>
+    <p>市区町村：<%= user.city %></p>
+    <p>投稿数：<%= user.spots.count %></p>
+    <p>フォロー数：<%= user.following.count %></p>
+    <p>フォロワー数：<%= user.followers.count %></p>
+  </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,8 @@ module JapanSiteInfo
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
+    # the framework and any gems in your application
+    config.autoload_paths += %W(#{config.root}/lib)
     config.time_zone = 'Asia/Tokyo'
     config.i18n.default_locale = :ja
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -277,10 +277,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
+  config.warden do |manager|
+    manager.failure_app = CustomAuthenticationFailure
   #   manager.intercept_401 = false
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/lib/custom_authentication_failure.rb
+++ b/lib/custom_authentication_failure.rb
@@ -1,0 +1,6 @@
+class CustomAuthenticationFailure < Devise::FailureApp
+  protected
+  def redirect_url
+     new_user_registration_path
+  end
+end


### PR DESCRIPTION
・ユーザー一覧、スポット一覧画面の作成
　(Ransack導入前準備)
・ヘッダー編集(「ユーザ一覧」「スポット一覧」へのリンク追加)
・devise、ログインしていないユーザーがログイン必須のページに遷移しようとした際の遷移先を新規登録画面に変更
　(以前はログイン画面が遷移先だったが、新規登録に失敗した際の遷移先がユーザー一覧画面であり、そこにバリデーションをかけていることて新規登録画面に遷移させたかったため。)