### PR TITLE
テスト記述 スポット詳細画面まで

### DIFF
--- a/app/views/spots/_search_spot.html.erb
+++ b/app/views/spots/_search_spot.html.erb
@@ -10,7 +10,7 @@
     </tr>
     <tr>
       <td class="search-label"><%= f.label "タイトル" %></td>
-      <td class="search-form"><%= f.search_field :title, placeholder: "(例) 東京タワー", class: "form-width" %></td>
+      <td class="search-form"><%= f.search_field :title_cont, placeholder: "(例) 東京タワー", class: "form-width" %></td>
     </tr>
     <tr>
       <td class="search-label"><%= f.label "キーワード" %></td>

--- a/spec/factories/keyword.rb
+++ b/spec/factories/keyword.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :keyword do
     keyword { Faker::Lorem.characters(number: 5) }
-    spot
   end
 end

--- a/spec/factories/keyword_relationship.rb
+++ b/spec/factories/keyword_relationship.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :keyword_relationship do
+    keyword
+    spot
+  end
+end

--- a/spec/factories/spots.rb
+++ b/spec/factories/spots.rb
@@ -10,5 +10,8 @@ FactoryBot.define do
     spot_image3 {'assets/image3.jpg'}
     content { Faker::Lorem.characters(number: 50) }
     user
+    after(:create) do |spot|
+      create(:keyword_relationship, spot: spot, keyword: create(:keyword))
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     prefecture {'東京都'}
     city { Faker::Lorem.characters(number: 5) }
     email { Faker::Internet.email }
+    profile_image { 'assets/image4.jpg' }
     introduction { Faker::Lorem.characters(number: 20) }
     password { 'password' }
     password_confirmation { 'password' }


### PR DESCRIPTION
【テスト】
・ユーザーログイン後
　ヘッダーの表示、スポット一覧、自分のスポット詳細画面のテスト