### PR TITLE
パスワード再設定メール 大枠作成

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,18 @@
-<p>Hello <%= @resource.email %>!</p>
+<%= @user.fullname %> 様
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+平素より JapanSiteInfo をご利用いただき誠にありがとうございます。
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+パスワード再設定の手続きを承りました。
+
+
+<%= link_to 'こちら', edit_password_url(@resource, reset_password_token: @token) %>のリンクより
+新たなパスワードをご入力ください。
+
+
+万一、当手続きの申請の覚えがないにもかかわらず当メールが届いた場合は、
+直ちに運営部までご連絡お願いいたします。
+
+
+JapanSiteInfo
+Email: ******@*****.com


### PR DESCRIPTION
reset_password_instructions内の文面作成
文章の大枠(送信元メールアドレス、リンク先以外)は完成